### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.fangxuele.tool</groupId>
@@ -26,7 +24,7 @@
         <emoji-java.version>5.1.1</emoji-java.version>
         <hutool-all.version>5.4.4</hutool-all.version>
         <opencsv.version>5.2</opencsv.version>
-        <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
+        <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
         <forms_rt.version>7.0.3</forms_rt.version>
         <fastjson.version>1.2.74</fastjson.version>
         <sun-mail.version>1.6.2</sun-mail.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 5.1.47
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.47 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS