### PR TITLE
fix(sec): upgrade org.apache.velocity:velocity-engine-core to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <AppleJavaExtensions.version>1.4</AppleJavaExtensions.version>
         <qcloudsms.version>1.0.6</qcloudsms.version>
         <yunpian-java-sdk.version>1.2.7</yunpian-java-sdk.version>
-        <velocity-engine-core.version>2.2</velocity-engine-core.version>
+        <velocity-engine-core.version>2.3</velocity-engine-core.version>
         <lombok.version>1.18.22</lombok.version>
         <mybatis.version>3.5.6</mybatis.version>
         <sqlite-jdbc.version>3.36.0.1</sqlite-jdbc.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.velocity:velocity-engine-core 2.2
- [CVE-2020-13936](https://www.oscs1024.com/hd/CVE-2020-13936)


### What did I do？
Upgrade org.apache.velocity:velocity-engine-core from 2.2 to 2.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS